### PR TITLE
Remove boost dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,11 +3,8 @@ project(L4 CXX)
 
 option(L4_COMPILE_UNIT_TESTS "Compile Tests; Requires Boost" ON)
 
-if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
-  message(FATAL_ERROR "Use provided solution file.")
-elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
   add_compile_options(-std=c++14)
-
   if(L4_COMPILE_UNIT_TESTS)
       add_definitions(-DBOOST_TEST_DYN_LINK)
   endif(L4_COMPILE_UNIT_TESTS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,10 +6,10 @@ if (POLICY CMP0077)
   cmake_policy(SET CMP0077 NEW)
 endif()
 
-option(L4_COMPILE_UNIT_TESTS "Compile Tests; Requires Boost" ON)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
-  add_compile_options(-std=c++17)
   if(L4_COMPILE_UNIT_TESTS)
       add_definitions(-DBOOST_TEST_DYN_LINK)
   endif(L4_COMPILE_UNIT_TESTS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,11 @@
 cmake_minimum_required(VERSION 2.8.12)
 project(L4 CXX)
 
+# Enable setting options from repository above.
+if (POLICY CMP0077)
+  cmake_policy(SET CMP0077 NEW)
+endif()
+
 option(L4_COMPILE_UNIT_TESTS "Compile Tests; Requires Boost" ON)
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ endif()
 option(L4_COMPILE_UNIT_TESTS "Compile Tests; Requires Boost" ON)
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
-  add_compile_options(-std=c++14)
+  add_compile_options(-std=c++17)
   if(L4_COMPILE_UNIT_TESTS)
       add_definitions(-DBOOST_TEST_DYN_LINK)
   endif(L4_COMPILE_UNIT_TESTS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,21 +1,28 @@
 cmake_minimum_required(VERSION 2.8.12)
 project(L4 CXX)
 
+option(L4_COMPILE_UNIT_TESTS "Compile Tests; Requires Boost" ON)
+
 if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
   message(FATAL_ERROR "Use provided solution file.")
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
   add_compile_options(-std=c++14)
-  add_definitions(-DBOOST_TEST_DYN_LINK)
+
+  if(L4_COMPILE_UNIT_TESTS)
+      add_definitions(-DBOOST_TEST_DYN_LINK)
+  endif(L4_COMPILE_UNIT_TESTS)
+
 endif()
 
-set(Boost_USE_STATIC_LIBS OFF) 
-set(Boost_USE_MULTITHREADED ON)  
-set(Boost_USE_STATIC_RUNTIME OFF) 
-find_package(Boost 1.45.0 COMPONENTS unit_test_framework REQUIRED)
-
-if(Boost_FOUND)
-    include_directories(${Boost_INCLUDE_DIRS}) 
-endif()
+if(L4_COMPILE_UNIT_TESTS)
+    set(Boost_USE_STATIC_LIBS OFF) 
+    set(Boost_USE_MULTITHREADED ON)  
+    set(Boost_USE_STATIC_RUNTIME OFF) 
+    find_package(Boost 1.45.0 COMPONENTS unit_test_framework REQUIRED)
+    if(Boost_FOUND)
+        include_directories(${Boost_INCLUDE_DIRS}) 
+    endif()
+endif(L4_COMPILE_UNIT_TESTS)
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}/inc
@@ -34,26 +41,28 @@ add_library(L4
     ${L4_SOURCES}
     ${L4_HEADERS})
 
-enable_testing()
+if(L4_COMPILE_UNIT_TESTS)
+    enable_testing()
+    add_executable(L4.UnitTests
+        Unittests/CacheHashTableTest.cpp
+        Unittests/EpochManagerTest.cpp
+        Unittests/HashTableManagerTest.cpp
+        Unittests/HashTableRecordTest.cpp
+        Unittests/HashTableServiceTest.cpp
+        Unittests/PerfInfoTest.cpp
+        Unittests/ReadWriteHashTableSerializerTest.cpp
+        Unittests/ReadWriteHashTableTest.cpp
+        Unittests/SettingAdapterTest.cpp
+        Unittests/Utils.cpp
+        Unittests/UtilsTest.cpp
+        Unittests/Main.cpp)
 
-add_executable(L4.UnitTests
-    Unittests/CacheHashTableTest.cpp
-    Unittests/EpochManagerTest.cpp
-    Unittests/HashTableManagerTest.cpp
-    Unittests/HashTableRecordTest.cpp
-    Unittests/HashTableServiceTest.cpp
-    Unittests/PerfInfoTest.cpp
-    Unittests/ReadWriteHashTableSerializerTest.cpp
-    Unittests/ReadWriteHashTableTest.cpp
-    Unittests/SettingAdapterTest.cpp
-    Unittests/Utils.cpp
-    Unittests/UtilsTest.cpp
-    Unittests/Main.cpp)
+    target_link_libraries(L4.UnitTests
+        L4
+        ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY}
+        -lpthread)
+        #${CMAKE_THREAD_LIBS_INIT})
 
-target_link_libraries(L4.UnitTests
-    L4
-    ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY}
-    -lpthread)
-    #${CMAKE_THREAD_LIBS_INIT})
+    add_test(NAME L4UnitTests COMMAND L4.UnitTests)
 
-add_test(NAME L4UnitTests COMMAND L4.UnitTests)
+endif(L4_COMPILE_UNIT_TESTS)

--- a/Unittests/EpochManagerTest.cpp
+++ b/Unittests/EpochManagerTest.cpp
@@ -17,7 +17,7 @@ BOOST_AUTO_TEST_CASE(EpochRefManagerTest) {
   const std::uint32_t c_epochQueueSize = 100U;
 
   using EpochQueue =
-      EpochQueue<boost::shared_lock_guard<L4::Utils::ReaderWriterLockSlim>,
+      EpochQueue<std::shared_lock<L4::Utils::ReaderWriterLockSlim>,
                  std::lock_guard<L4::Utils::ReaderWriterLockSlim>>;
 
   EpochQueue epochQueue(currentEpochCounter, c_epochQueueSize);
@@ -50,7 +50,7 @@ BOOST_AUTO_TEST_CASE(EpochCounterManagerTest) {
   const std::uint32_t c_epochQueueSize = 100U;
 
   using EpochQueue =
-      EpochQueue<boost::shared_lock_guard<L4::Utils::ReaderWriterLockSlim>,
+      EpochQueue<std::shared_lock<L4::Utils::ReaderWriterLockSlim>,
                  std::lock_guard<L4::Utils::ReaderWriterLockSlim>>;
 
   EpochQueue epochQueue(currentEpochCounter, c_epochQueueSize);

--- a/inc/L4/Epoch/EpochQueue.h
+++ b/inc/L4/Epoch/EpochQueue.h
@@ -46,12 +46,12 @@ struct EpochQueue {
   // The followings (m_frontIndex and m_backIndex) are
   // accessed/updated only by the owner thread (only one thread), thus
   // they don't require any synchronization.
-  std::size_t m_frontIndex;
+  std::uint64_t m_frontIndex;
 
   // Back index represents the latest epoch counter value. Note that
   // this is accessed/updated by multiple threads, thus requires
   // synchronization.
-  std::size_t m_backIndex;
+  std::uint64_t m_backIndex;
 
   // Read/Write lock for m_backIndex.
   typename SharableLock::mutex_type m_mutexForBackIndex;

--- a/inc/L4/Epoch/EpochQueue.h
+++ b/inc/L4/Epoch/EpochQueue.h
@@ -4,7 +4,6 @@
 #include <atomic>
 #include <memory>
 #include <mutex>
-#include "Interprocess/Container/Vector.h"
 #include "Utils/Exception.h"
 #include "Utils/Lock.h"
 

--- a/inc/L4/Epoch/EpochQueue.h
+++ b/inc/L4/Epoch/EpochQueue.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <vector>
 #include <atomic>
 #include <memory>
 #include <mutex>
@@ -38,8 +39,10 @@ struct EpochQueue {
   using SharableLock = TSharableLock;
   using ExclusiveLock = TExclusiveLock;
   using RefCount = std::atomic<std::uint32_t>;
-  using RefCounts = Interprocess::Container::
-      Vector<RefCount, typename Allocator::template rebind<RefCount>::other>;
+  // @jerinphilip: dirty-fix, browsermt/L4 hopefully does not need IPC.
+  // using RefCounts = Interprocess::Container::
+  //     Vector<RefCount, typename Allocator::template rebind<RefCount>::other>;
+  using RefCounts = std::vector<RefCount, typename Allocator::template rebind<RefCount>::other>;
 
   // The followings (m_frontIndex and m_backIndex) are
   // accessed/updated only by the owner thread (only one thread), thus

--- a/inc/L4/Epoch/EpochRefPolicy.h
+++ b/inc/L4/Epoch/EpochRefPolicy.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <boost/integer_traits.hpp>
 #include <cstdint>
+#include <limits>
 
 namespace L4 {
 
@@ -17,11 +17,11 @@ class EpochRefPolicy {
       : m_epochRefManager{epochRefPolicy.m_epochRefManager},
         m_epochCounter{epochRefPolicy.m_epochCounter} {
     epochRefPolicy.m_epochCounter =
-        boost::integer_traits<std::uint64_t>::const_max;
+        std::numeric_limits<std::uint64_t>::max();
   }
 
   ~EpochRefPolicy() {
-    if (m_epochCounter != boost::integer_traits<std::uint64_t>::const_max) {
+    if (m_epochCounter != std::numeric_limits<std::uint64_t>::max()) {
       m_epochRefManager.RemoveRef(m_epochCounter);
     }
   }

--- a/inc/L4/HashTable/Common/Record.h
+++ b/inc/L4/HashTable/Common/Record.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <cstring>
 #include "HashTable/IHashTable.h"
 #include "Utils/Exception.h"
 
@@ -73,14 +74,8 @@ class RecordSerializer {
 
     const auto start = SerializeSizes(buffer, key.m_size, value.m_size);
 
-#if defined(_MSC_VER)
-    memcpy_s(buffer + start, key.m_size, key.m_data, key.m_size);
-    memcpy_s(buffer + start + key.m_size, value.m_size, value.m_data,
-             value.m_size);
-#else
-    memcpy(buffer + start, key.m_data, key.m_size);
-    memcpy(buffer + start + key.m_size, value.m_data, value.m_size);
-#endif
+    std::memcpy(buffer + start, key.m_data, key.m_size);
+    std::memcpy(buffer + start + key.m_size, value.m_data, value.m_size);
     return reinterpret_cast<RecordBuffer*>(buffer);
   }
 

--- a/inc/L4/HashTable/Common/SettingAdapter.h
+++ b/inc/L4/HashTable/Common/SettingAdapter.h
@@ -18,9 +18,9 @@ class SettingAdapter {
 
     to.m_numBuckets = from.m_numBuckets;
     to.m_numBucketsPerMutex =
-        (std::max)(from.m_numBucketsPerMutex.get_value_or(1U), 1U);
-    to.m_fixedKeySize = from.m_fixedKeySize.get_value_or(0U);
-    to.m_fixedValueSize = from.m_fixedValueSize.get_value_or(0U);
+        (std::max)(from.m_numBucketsPerMutex.value_or(1U), 1U);
+    to.m_fixedKeySize = from.m_fixedKeySize.value_or(0U);
+    to.m_fixedValueSize = from.m_fixedValueSize.value_or(0U);
 
     return to;
   }

--- a/inc/L4/HashTable/Config.h
+++ b/inc/L4/HashTable/Config.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <boost/optional.hpp>
+#include <optional>
 #include <cassert>
 #include <chrono>
 #include <cstdint>
@@ -17,18 +17,18 @@ struct HashTableConfig {
     using ValueSize = IReadOnlyHashTable::Value::size_type;
 
     explicit Setting(std::uint32_t numBuckets,
-                     boost::optional<std::uint32_t> numBucketsPerMutex = {},
-                     boost::optional<KeySize> fixedKeySize = {},
-                     boost::optional<ValueSize> fixedValueSize = {})
+                     std::optional<std::uint32_t> numBucketsPerMutex = {},
+                     std::optional<KeySize> fixedKeySize = {},
+                     std::optional<ValueSize> fixedValueSize = {})
         : m_numBuckets{numBuckets},
           m_numBucketsPerMutex{numBucketsPerMutex},
           m_fixedKeySize{fixedKeySize},
           m_fixedValueSize{fixedValueSize} {}
 
     std::uint32_t m_numBuckets;
-    boost::optional<std::uint32_t> m_numBucketsPerMutex;
-    boost::optional<KeySize> m_fixedKeySize;
-    boost::optional<ValueSize> m_fixedValueSize;
+    std::optional<std::uint32_t> m_numBucketsPerMutex;
+    std::optional<KeySize> m_fixedKeySize;
+    std::optional<ValueSize> m_fixedValueSize;
   };
 
   struct Cache {
@@ -48,17 +48,17 @@ struct HashTableConfig {
     using Properties = Utils::Properties;
 
     Serializer(std::shared_ptr<std::istream> stream = {},
-               boost::optional<Properties> properties = {})
+               std::optional<Properties> properties = {})
         : m_stream{stream}, m_properties{properties} {}
 
     std::shared_ptr<std::istream> m_stream;
-    boost::optional<Properties> m_properties;
+    std::optional<Properties> m_properties;
   };
 
   HashTableConfig(std::string name,
                   Setting setting,
-                  boost::optional<Cache> cache = {},
-                  boost::optional<Serializer> serializer = {})
+                  std::optional<Cache> cache = {},
+                  std::optional<Serializer> serializer = {})
       : m_name{std::move(name)},
         m_setting{std::move(setting)},
         m_cache{cache},
@@ -69,8 +69,8 @@ struct HashTableConfig {
 
   std::string m_name;
   Setting m_setting;
-  boost::optional<Cache> m_cache;
-  boost::optional<Serializer> m_serializer;
+  std::optional<Cache> m_cache;
+  std::optional<Serializer> m_serializer;
 };
 
 }  // namespace L4

--- a/inc/L4/HashTable/IHashTable.h
+++ b/inc/L4/HashTable/IHashTable.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <cstring>
 #include <iosfwd>
 #include "Log/PerfCounter.h"
 #include "Utils/Properties.h"
@@ -21,7 +22,7 @@ struct IReadOnlyHashTable {
     }
 
     bool operator==(const Blob& other) const {
-      return (m_size == other.m_size) && !memcmp(m_data, other.m_data, m_size);
+      return (m_size == other.m_size) && !std::memcmp(m_data, other.m_data, m_size);
     }
 
     bool operator!=(const Blob& other) const { return !(*this == other); }

--- a/inc/L4/HashTable/ReadWrite/HashTable.h
+++ b/inc/L4/HashTable/ReadWrite/HashTable.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <boost/optional.hpp>
+#include <optional>
 #include <cstdint>
 #include <mutex>
 #include "Epoch/IEpochActionManager.h"
@@ -32,7 +32,7 @@ class ReadOnlyHashTable : public virtual IReadOnlyHashTable {
 
   explicit ReadOnlyHashTable(
       HashTable& hashTable,
-      boost::optional<RecordSerializer> recordSerializer = boost::none)
+      std::optional<RecordSerializer> recordSerializer = boost::none)
       : m_hashTable{hashTable},
         m_recordSerializer{
             recordSerializer

--- a/inc/L4/HashTable/ReadWrite/HashTable.h
+++ b/inc/L4/HashTable/ReadWrite/HashTable.h
@@ -2,8 +2,6 @@
 
 #include <cstdint>
 #include <mutex>
-#include <optional>
-
 #include "Epoch/IEpochActionManager.h"
 #include "HashTable/Common/Record.h"
 #include "HashTable/Common/SharedHashTable.h"
@@ -31,11 +29,15 @@ class ReadOnlyHashTable : public virtual IReadOnlyHashTable {
 
   class Iterator;
 
-  explicit ReadOnlyHashTable(HashTable& hashTable, std::optional<RecordSerializer> recordSerializer = std::nullopt)
+  explicit ReadOnlyHashTable(
+      HashTable& hashTable,
+      std::optional<RecordSerializer> recordSerializer = {})
       : m_hashTable{hashTable},
-        m_recordSerializer{recordSerializer ? *recordSerializer
-                                            : RecordSerializer{m_hashTable.m_setting.m_fixedKeySize,
-                                                               m_hashTable.m_setting.m_fixedValueSize}} {}
+        m_recordSerializer{
+            recordSerializer
+                ? *recordSerializer
+                : RecordSerializer{m_hashTable.m_setting.m_fixedKeySize,
+                                   m_hashTable.m_setting.m_fixedValueSize}} {}
 
   virtual bool Get(const Key& key, Value& value) const override {
     const auto bucketInfo = GetBucketInfo(key);
@@ -48,7 +50,8 @@ class ReadOnlyHashTable : public virtual IReadOnlyHashTable {
           // during access. Therefore, load it once and save it (it's safe to
           // store it b/c the memory will not be deleted until ref count becomes
           // 0).
-          const auto data = entry->m_dataList[i].Load(std::memory_order_acquire);
+          const auto data =
+              entry->m_dataList[i].Load(std::memory_order_acquire);
 
           if (data != nullptr) {
             const auto record = m_recordSerializer.Deserialize(*data);
@@ -94,7 +97,8 @@ class ReadOnlyHashTable : public virtual IReadOnlyHashTable {
     std::array<std::uint64_t, 2> hash;
     MurmurHash3_x64_128(key.m_data, key.m_size, 0U, hash.data());
 
-    return {static_cast<std::uint32_t>(hash[0] % m_hashTable.m_buckets.size()), static_cast<std::uint8_t>(hash[1])};
+    return {static_cast<std::uint32_t>(hash[0] % m_hashTable.m_buckets.size()),
+            static_cast<std::uint8_t>(hash[1])};
   }
 
   HashTable& m_hashTable;
@@ -107,7 +111,8 @@ class ReadOnlyHashTable : public virtual IReadOnlyHashTable {
 template <typename Allocator>
 class ReadOnlyHashTable<Allocator>::Iterator : public IIterator {
  public:
-  Iterator(const HashTable& hashTable, const RecordSerializer& recordDeserializer)
+  Iterator(const HashTable& hashTable,
+           const RecordSerializer& recordDeserializer)
       : m_hashTable{hashTable},
         m_recordSerializer{recordDeserializer},
         m_currentBucketIndex{-1},
@@ -139,7 +144,9 @@ class ReadOnlyHashTable<Allocator>::Iterator : public IIterator {
     assert(m_currentRecordIndex < HashTable::Entry::c_numDataPerEntry);
 
     while ((m_currentEntry == nullptr) ||
-           (m_currentRecord = m_currentEntry->m_dataList[m_currentRecordIndex].Load()) == nullptr) {
+           (m_currentRecord =
+                m_currentEntry->m_dataList[m_currentRecordIndex].Load()) ==
+               nullptr) {
       if (m_currentEntry == nullptr) {
         ++m_currentBucketIndex;
         m_currentRecordIndex = 0U;
@@ -180,9 +187,15 @@ class ReadOnlyHashTable<Allocator>::Iterator : public IIterator {
   Iterator& operator=(const Iterator&) = delete;
 
  private:
-  bool IsValid() const { return !IsEnd() && (m_currentEntry != nullptr) && (m_currentRecord != nullptr); }
+  bool IsValid() const {
+    return !IsEnd() && (m_currentEntry != nullptr) &&
+           (m_currentRecord != nullptr);
+  }
 
-  bool IsEnd() const { return m_currentBucketIndex == static_cast<std::int64_t>(m_hashTable.m_buckets.size()); }
+  bool IsEnd() const {
+    return m_currentBucketIndex ==
+           static_cast<std::int64_t>(m_hashTable.m_buckets.size());
+  }
 
   void MoveToNextData() {
     if (++m_currentRecordIndex >= HashTable::Entry::c_numDataPerEntry) {
@@ -211,7 +224,8 @@ class ReadOnlyHashTable<Allocator>::Iterator : public IIterator {
 // inheritance on ReadOnlyHashTable<Allocator> so that any derived class can
 // have only one ReadOnlyHashTable base class instance.
 template <typename Allocator>
-class WritableHashTable : public virtual ReadOnlyHashTable<Allocator>, public IWritableHashTable {
+class WritableHashTable : public virtual ReadOnlyHashTable<Allocator>,
+                          public IWritableHashTable {
  public:
   using Base = ReadOnlyHashTable<Allocator>;
   using HashTable = typename Base::HashTable;
@@ -219,7 +233,9 @@ class WritableHashTable : public virtual ReadOnlyHashTable<Allocator>, public IW
   WritableHashTable(HashTable& hashTable, IEpochActionManager& epochManager)
       : Base(hashTable), m_epochManager{epochManager} {}
 
-  virtual void Add(const Key& key, const Value& value) override { Add(CreateRecordBuffer(key, value)); }
+  virtual void Add(const Key& key, const Value& value) override {
+    Add(CreateRecordBuffer(key, value));
+  }
 
   virtual bool Remove(const Key& key) override {
     const auto bucketInfo = this->GetBucketInfo(key);
@@ -234,7 +250,8 @@ class WritableHashTable : public virtual ReadOnlyHashTable<Allocator>, public IW
     while (entry != nullptr) {
       for (std::uint8_t i = 0; i < HashTable::Entry::c_numDataPerEntry; ++i) {
         if (bucketInfo.second == entry->m_tags[i]) {
-          const auto data = entry->m_dataList[i].Load(std::memory_order_relaxed);
+          const auto data =
+              entry->m_dataList[i].Load(std::memory_order_relaxed);
 
           if (data != nullptr) {
             const auto record = this->m_recordSerializer.Deserialize(*data);
@@ -273,7 +290,8 @@ class WritableHashTable : public virtual ReadOnlyHashTable<Allocator>, public IW
     typename HashTable::Entry* entryToUpdate = nullptr;
     std::uint8_t curDataIndex = 0U;
 
-    typename HashTable::UniqueLock lock{this->m_hashTable.GetMutex(bucketInfo.first)};
+    typename HashTable::UniqueLock lock{
+        this->m_hashTable.GetMutex(bucketInfo.first)};
 
     // Note that the following block is performed inside a critical section,
     // therefore, it is safe to do "Load"s with memory_order_relaxed.
@@ -281,7 +299,8 @@ class WritableHashTable : public virtual ReadOnlyHashTable<Allocator>, public IW
       ++stat.m_chainIndex;
 
       for (std::uint8_t i = 0; i < HashTable::Entry::c_numDataPerEntry; ++i) {
-        const auto data = curEntry->m_dataList[i].Load(std::memory_order_relaxed);
+        const auto data =
+            curEntry->m_dataList[i].Load(std::memory_order_relaxed);
 
         if (data == nullptr) {
           if (entryToUpdate == nullptr) {
@@ -309,11 +328,14 @@ class WritableHashTable : public virtual ReadOnlyHashTable<Allocator>, public IW
 
       // Check if this is the end of the chaining. If so, create a new entry if
       // we haven't found any entry to update along the way.
-      if (entryToUpdate == nullptr && curEntry->m_next.Load(std::memory_order_relaxed) == nullptr) {
-        curEntry->m_next.Store(new (Detail::to_raw_pointer(
-                                   this->m_hashTable.template GetAllocator<typename HashTable::Entry>().allocate(1U)))
-                                   typename HashTable::Entry(),
-                               std::memory_order_release);
+      if (entryToUpdate == nullptr &&
+          curEntry->m_next.Load(std::memory_order_relaxed) == nullptr) {
+        curEntry->m_next.Store(
+            new (Detail::to_raw_pointer(
+                this->m_hashTable
+                    .template GetAllocator<typename HashTable::Entry>()
+                    .allocate(1U))) typename HashTable::Entry(),
+            std::memory_order_release);
 
         stat.m_isNewEntryAdded = true;
       }
@@ -323,7 +345,8 @@ class WritableHashTable : public virtual ReadOnlyHashTable<Allocator>, public IW
 
     assert(entryToUpdate != nullptr);
 
-    auto recordToDelete = UpdateRecord(*entryToUpdate, curDataIndex, recordToAdd, bucketInfo.second);
+    auto recordToDelete = UpdateRecord(*entryToUpdate, curDataIndex,
+                                       recordToAdd, bucketInfo.second);
 
     lock.unlock();
 
@@ -341,7 +364,8 @@ class WritableHashTable : public virtual ReadOnlyHashTable<Allocator>, public IW
 
     const auto record = this->m_recordSerializer.Deserialize(*recordToDelete);
 
-    UpdatePerfDataForRemove(Stat{record.m_key.m_size, record.m_value.m_size, 0U});
+    UpdatePerfDataForRemove(
+        Stat{record.m_key.m_size, record.m_value.m_size, 0U});
 
     ReleaseRecord(recordToDelete);
   }
@@ -352,13 +376,18 @@ class WritableHashTable : public virtual ReadOnlyHashTable<Allocator>, public IW
   class Serializer;
 
   RecordBuffer* CreateRecordBuffer(const Key& key, const Value& value) {
-    const auto bufferSize = this->m_recordSerializer.CalculateBufferSize(key, value);
-    auto buffer = Detail::to_raw_pointer(this->m_hashTable.template GetAllocator<std::uint8_t>().allocate(bufferSize));
+    const auto bufferSize =
+        this->m_recordSerializer.CalculateBufferSize(key, value);
+    auto buffer = Detail::to_raw_pointer(
+        this->m_hashTable.template GetAllocator<std::uint8_t>().allocate(
+            bufferSize));
 
     return this->m_recordSerializer.Serialize(key, value, buffer, bufferSize);
   }
 
-  RecordBuffer* UpdateRecord(typename HashTable::Entry& entry, std::uint8_t index, RecordBuffer* newRecord,
+  RecordBuffer* UpdateRecord(typename HashTable::Entry& entry,
+                             std::uint8_t index,
+                             RecordBuffer* newRecord,
                              std::uint8_t newTag) {
     // This function should be called under a lock, so calling with
     // memory_order_relaxed for Load() is safe.
@@ -378,7 +407,8 @@ class WritableHashTable : public virtual ReadOnlyHashTable<Allocator>, public IW
 
     m_epochManager.RegisterAction([this, record]() {
       record->~RecordBuffer();
-      this->m_hashTable.template GetAllocator<RecordBuffer>().deallocate(record, 1U);
+      this->m_hashTable.template GetAllocator<RecordBuffer>().deallocate(record,
+                                                                         1U);
     });
   }
 
@@ -388,16 +418,19 @@ class WritableHashTable : public virtual ReadOnlyHashTable<Allocator>, public IW
     if (stat.m_oldValueSize != 0U) {
       // Updating the existing record. Therefore, no change in the key size.
       perfData.Add(HashTablePerfCounter::TotalValueSize,
-                   static_cast<HashTablePerfData::TValue>(stat.m_valueSize) - stat.m_oldValueSize);
+                   static_cast<HashTablePerfData::TValue>(stat.m_valueSize) -
+                       stat.m_oldValueSize);
     } else {
       // We are adding a new data instead of replacing.
       perfData.Add(HashTablePerfCounter::TotalKeySize, stat.m_keySize);
       perfData.Add(HashTablePerfCounter::TotalValueSize, stat.m_valueSize);
-      perfData.Add(HashTablePerfCounter::TotalIndexSize,
-                   // Record overhead.
-                   this->m_recordSerializer.CalculateRecordOverhead()
-                       // Entry overhead if created.
-                       + (stat.m_isNewEntryAdded ? sizeof(typename HashTable::Entry) : 0U));
+      perfData.Add(
+          HashTablePerfCounter::TotalIndexSize,
+          // Record overhead.
+          this->m_recordSerializer.CalculateRecordOverhead()
+              // Entry overhead if created.
+              + (stat.m_isNewEntryAdded ? sizeof(typename HashTable::Entry)
+                                        : 0U));
 
       perfData.Min(HashTablePerfCounter::MinKeySize, stat.m_keySize);
       perfData.Max(HashTablePerfCounter::MaxKeySize, stat.m_keySize);
@@ -408,7 +441,8 @@ class WritableHashTable : public virtual ReadOnlyHashTable<Allocator>, public IW
         perfData.Increment(HashTablePerfCounter::ChainingEntriesCount);
 
         if (stat.m_chainIndex > 1U) {
-          perfData.Max(HashTablePerfCounter::MaxBucketChainLength, stat.m_chainIndex);
+          perfData.Max(HashTablePerfCounter::MaxBucketChainLength,
+                       stat.m_chainIndex);
         }
       }
     }
@@ -423,7 +457,8 @@ class WritableHashTable : public virtual ReadOnlyHashTable<Allocator>, public IW
     perfData.Decrement(HashTablePerfCounter::RecordsCount);
     perfData.Subtract(HashTablePerfCounter::TotalKeySize, stat.m_keySize);
     perfData.Subtract(HashTablePerfCounter::TotalValueSize, stat.m_valueSize);
-    perfData.Subtract(HashTablePerfCounter::TotalIndexSize, this->m_recordSerializer.CalculateRecordOverhead());
+    perfData.Subtract(HashTablePerfCounter::TotalIndexSize,
+                      this->m_recordSerializer.CalculateRecordOverhead());
   }
 
   IEpochActionManager& m_epochManager;
@@ -437,8 +472,11 @@ struct WritableHashTable<Allocator>::Stat {
   using KeySize = Key::size_type;
   using ValueSize = Value::size_type;
 
-  explicit Stat(KeySize keySize = 0U, ValueSize valueSize = 0U, ValueSize oldValueSize = 0U,
-                std::uint32_t chainIndex = 0U, bool isNewEntryAdded = false)
+  explicit Stat(KeySize keySize = 0U,
+                ValueSize valueSize = 0U,
+                ValueSize oldValueSize = 0U,
+                std::uint32_t chainIndex = 0U,
+                bool isNewEntryAdded = false)
       : m_keySize{keySize},
         m_valueSize{valueSize},
         m_oldValueSize{oldValueSize},
@@ -455,15 +493,18 @@ struct WritableHashTable<Allocator>::Stat {
 // WritableHashTable::Serializer class that implements ISerializer, which
 // provides the functionality to serialize the WritableHashTable.
 template <typename Allocator>
-class WritableHashTable<Allocator>::Serializer : public IWritableHashTable::ISerializer {
+class WritableHashTable<Allocator>::Serializer
+    : public IWritableHashTable::ISerializer {
  public:
   explicit Serializer(HashTable& hashTable) : m_hashTable{hashTable} {}
 
   Serializer(const Serializer&) = delete;
   Serializer& operator=(const Serializer&) = delete;
 
-  void Serialize(std::ostream& stream, const Utils::Properties& /* properties */) override {
-    ReadWrite::Serializer<HashTable, ReadWrite::ReadOnlyHashTable>{}.Serialize(m_hashTable, stream);
+  void Serialize(std::ostream& stream,
+                 const Utils::Properties& /* properties */) override {
+    ReadWrite::Serializer<HashTable, ReadWrite::ReadOnlyHashTable>{}.Serialize(
+        m_hashTable, stream);
   }
 
  private:

--- a/inc/L4/HashTable/ReadWrite/HashTable.h
+++ b/inc/L4/HashTable/ReadWrite/HashTable.h
@@ -31,10 +31,10 @@ class ReadOnlyHashTable : public virtual IReadOnlyHashTable {
 
   explicit ReadOnlyHashTable(
       HashTable& hashTable,
-      std::optional<RecordSerializer> recordSerializer = {})
+      std::optional<RecordSerializer> recordSerializer = std::nullopt)
       : m_hashTable{hashTable},
         m_recordSerializer{
-            recordSerializer
+            recordSerializer.has_value()
                 ? *recordSerializer
                 : RecordSerializer{m_hashTable.m_setting.m_fixedKeySize,
                                    m_hashTable.m_setting.m_fixedValueSize}} {}

--- a/inc/L4/HashTable/ReadWrite/HashTable.h
+++ b/inc/L4/HashTable/ReadWrite/HashTable.h
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <mutex>
+#include <optional>
 #include "Epoch/IEpochActionManager.h"
 #include "HashTable/Common/Record.h"
 #include "HashTable/Common/SharedHashTable.h"

--- a/inc/L4/HashTable/ReadWrite/Serializer.h
+++ b/inc/L4/HashTable/ReadWrite/Serializer.h
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <iosfwd>
+#include <iostream>
 #include "Epoch/IEpochActionManager.h"
 #include "Log/PerfCounter.h"
 #include "Serialization/SerializerHelper.h"
@@ -202,7 +203,7 @@ class Deserializer {
             m_properties}
             .Deserialize(memory, stream);
       default:
-        std::stringstream err;
+        std::ostringstream err;
         err << "Unsupported version " << version << " is given.";
         throw RuntimeException(err.str());
     }

--- a/inc/L4/HashTable/ReadWrite/Serializer.h
+++ b/inc/L4/HashTable/ReadWrite/Serializer.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <boost/format.hpp>
 #include <cstdint>
 #include <iosfwd>
 #include "Epoch/IEpochActionManager.h"
@@ -203,8 +202,8 @@ class Deserializer {
             m_properties}
             .Deserialize(memory, stream);
       default:
-        boost::format err("Unsupported version '%1%' is given.");
-        err % version;
+        std::stringstream err;
+        err << "Unsupported version " << version << " is given.";
         throw RuntimeException(err.str());
     }
   }

--- a/inc/L4/HashTable/ReadWrite/Serializer.h
+++ b/inc/L4/HashTable/ReadWrite/Serializer.h
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <iosfwd>
 #include <iostream>
+#include <sstream>
 #include "Epoch/IEpochActionManager.h"
 #include "Log/PerfCounter.h"
 #include "Serialization/SerializerHelper.h"
@@ -204,7 +205,7 @@ class Deserializer {
             .Deserialize(memory, stream);
       default:
         std::ostringstream err;
-        err << "Unsupported version " << version << " is given.";
+        err << std::string("Unsupported version ") << version << std::string(" is given.");
         throw RuntimeException(err.str());
     }
   }

--- a/inc/L4/Interprocess/Container/Vector.h
+++ b/inc/L4/Interprocess/Container/Vector.h
@@ -1,13 +1,17 @@
 #pragma once
 
-#include <boost/interprocess/containers/vector.hpp>
+// #include <boost/interprocess/containers/vector.hpp>
+#include <vector>
 
 namespace L4 {
 namespace Interprocess {
 namespace Container {
 
+// template <typename T, typename Allocator>
+// using Vector = boost::interprocess::vector<T, Allocator>;
+// @jerinphilip: This is probably a bad idea.
 template <typename T, typename Allocator>
-using Vector = boost::interprocess::vector<T, Allocator>;
+using Vector = std::vector<T, Allocator>;
 
 }  // namespace Container
 }  // namespace Interprocess

--- a/inc/L4/LocalMemory/EpochManager.h
+++ b/inc/L4/LocalMemory/EpochManager.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <atomic>
-#include <boost/thread/shared_lock_guard.hpp>
 #include <mutex>
+#include <shared_mutex>
 #include "Epoch/Config.h"
 #include "Epoch/EpochActionManager.h"
 #include "Epoch/EpochQueue.h"
@@ -19,7 +19,7 @@ namespace LocalMemory {
 class EpochManager : public IEpochActionManager {
  public:
   using TheEpochQueue =
-      EpochQueue<boost::shared_lock_guard<Utils::ReaderWriterLockSlim>,
+      EpochQueue<std::shared_lock<Utils::ReaderWriterLockSlim>,
                  std::lock_guard<Utils::ReaderWriterLockSlim>>;
 
   using TheEpochRefManager = EpochRefManager<TheEpochQueue>;

--- a/inc/L4/LocalMemory/HashTableManager.h
+++ b/inc/L4/LocalMemory/HashTableManager.h
@@ -46,18 +46,18 @@ class HashTableManager {
         (serializerConfig && serializerConfig->m_stream != nullptr)
             ? ReadWrite::Deserializer<Memory, InternalHashTable,
                                       ReadWrite::WritableHashTable>(
-                  serializerConfig->m_properties.get_value_or(
+                  serializerConfig->m_properties.value_or(
                       HashTableConfig::Serializer::Properties()))
                   .Deserialize(memory, *(serializerConfig->m_stream))
             : memory.template MakeUnique<InternalHashTable>(
                   typename InternalHashTable::Setting{
                       config.m_setting.m_numBuckets,
                       (std::max)(
-                          config.m_setting.m_numBucketsPerMutex.get_value_or(
+                          config.m_setting.m_numBucketsPerMutex.value_or(
                               1U),
                           1U),
-                      config.m_setting.m_fixedKeySize.get_value_or(0U),
-                      config.m_setting.m_fixedValueSize.get_value_or(0U)},
+                      config.m_setting.m_fixedKeySize.value_or(0U),
+                      config.m_setting.m_fixedValueSize.value_or(0U)},
                   memory.GetAllocator());
 
     auto hashTable =

--- a/inc/L4/LocalMemory/HashTableManager.h
+++ b/inc/L4/LocalMemory/HashTableManager.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <boost/any.hpp>
+#include <any>
 #include <memory>
 #include <vector>
 #include "Epoch/IEpochActionManager.h"
@@ -92,7 +92,7 @@ class HashTableManager {
  private:
   Utils::StdStringKeyMap<std::size_t> m_hashTableNameToIndex;
 
-  std::vector<boost::any> m_internalHashTables;
+  std::vector<std::any> m_internalHashTables;
   std::vector<std::unique_ptr<IWritableHashTable>> m_hashTables;
 };
 

--- a/inc/L4/Log/IPerfLogger.h
+++ b/inc/L4/Log/IPerfLogger.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <map>
+#include <functional>
 #include "PerfCounter.h"
 
 namespace L4 {

--- a/inc/L4/Serialization/SerializerHelper.h
+++ b/inc/L4/Serialization/SerializerHelper.h
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <iosfwd>
+#include <iostream>
 
 namespace L4 {
 

--- a/inc/L4/Utils/AtomicOffsetPtr.h
+++ b/inc/L4/Utils/AtomicOffsetPtr.h
@@ -1,8 +1,7 @@
 #pragma once
 
 #include <atomic>
-#include <boost/interprocess/offset_ptr.hpp>
-#include <boost/version.hpp>
+#include <detail/ToRawPointer.h>
 #include <cstdint>
 
 namespace L4 {
@@ -26,15 +25,14 @@ class AtomicOffsetPtr {
 
   T* Load(std::memory_order memoryOrder = std::memory_order_seq_cst) const {
     return static_cast<T*>(
-        boost::interprocess::ipcdetail::offset_ptr_to_raw_pointer(
+        L4::Detail::offset_ptr_to_raw_pointer(
             this, m_offset.load(memoryOrder)));
   }
 
   void Store(T* ptr,
              std::memory_order memoryOrder = std::memory_order_seq_cst) {
     m_offset.store(
-        boost::interprocess::ipcdetail::offset_ptr_to_offset<std::uintptr_t>(
-            ptr, this),
+        L4::Detail::offset_ptr_to_offset<std::uintptr_t>(ptr, this),
         memoryOrder);
   }
 

--- a/inc/L4/Utils/ComparerHasher.h
+++ b/inc/L4/Utils/ComparerHasher.h
@@ -5,8 +5,12 @@
 #include <string>
 
 #if defined(__GNUC__)
+#include <strings.h>
 #define _stricmp strcasecmp
 #endif
+
+namespace L4 {
+namespace Utils {
 
 namespace {
 
@@ -15,13 +19,10 @@ namespace {
 template <class T>
 inline void hash_combine(std::size_t& seed, const T& v) {
   std::hash<T> hasher;
-  seed ^= hasher(v) + 0x9e3779b9 + (seed<<6) + (seed>>2);
+  seed ^= hasher(v) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
 }
 
-}
-
-namespace L4 {
-namespace Utils {
+}  // namespace
 
 // CaseInsensitiveStdStringComparer is a STL-compatible case-insensitive ANSI
 // std::string comparer.
@@ -34,9 +35,7 @@ struct CaseInsensitiveStdStringComparer {
 // CaseInsensitiveStringComparer is a STL-compatible case-insensitive ANSI
 // string comparer.
 struct CaseInsensitiveStringComparer {
-  bool operator()(const char* const str1, const char* const str2) const {
-    return _stricmp(str1, str2) == 0;
-  }
+  bool operator()(const char* const str1, const char* const str2) const { return _stricmp(str1, str2) == 0; }
 };
 
 // CaseInsensitiveStringHasher is a STL-compatible case-insensitive ANSI

--- a/inc/L4/Utils/ComparerHasher.h
+++ b/inc/L4/Utils/ComparerHasher.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <boost/functional/hash.hpp>
 #include <cctype>
 #include <cstdint>
 #include <string>
@@ -8,6 +7,18 @@
 #if defined(__GNUC__)
 #define _stricmp strcasecmp
 #endif
+
+namespace {
+
+// https://stackoverflow.com/questions/4948780/magic-number-in-boosthash-combine
+// http://burtleburtle.net/bob/hash/doobs.html
+template <class T>
+inline void hash_combine(std::size_t& seed, const T& v) {
+  std::hash<T> hasher;
+  seed ^= hasher(v) + 0x9e3779b9 + (seed<<6) + (seed>>2);
+}
+
+}
 
 namespace L4 {
 namespace Utils {
@@ -35,7 +46,7 @@ struct CaseInsensitiveStdStringHasher {
     std::size_t seed = 0;
 
     for (auto c : str) {
-      boost::hash_combine(seed, std::toupper(c));
+      hash_combine(seed, std::toupper(c));
     }
 
     return seed;
@@ -51,7 +62,7 @@ struct CaseInsensitiveStringHasher {
     std::size_t seed = 0;
 
     while (*str) {
-      boost::hash_combine(seed, std::toupper(*str++));
+      hash_combine(seed, std::toupper(*str++));
     }
 
     return seed;

--- a/inc/L4/Utils/Containers.h
+++ b/inc/L4/Utils/Containers.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <boost/functional/hash.hpp>
 #include <cstdint>
 #include <string>
 #include <unordered_map>
@@ -28,10 +27,10 @@ using StringKeyMap = std::unordered_map<const char*,
                                         Utils::CaseInsensitiveStringHasher,
                                         Utils::CaseInsensitiveStringComparer>;
 
-// IntegerKeyMap using boost::hash and std::equal_to comparer and hasher.
+// IntegerKeyMap using std::hash and std::equal_to comparer and hasher.
 template <typename TKey, typename TValue>
 using IntegerKeyMap =
-    std::unordered_map<TKey, TValue, boost::hash<TKey>, std::equal_to<TKey>>;
+    std::unordered_map<TKey, TValue, std::hash<TKey>, std::equal_to<TKey>>;
 
 }  // namespace Utils
 }  // namespace L4

--- a/inc/L4/Utils/Properties.h
+++ b/inc/L4/Utils/Properties.h
@@ -2,7 +2,6 @@
 
 #include "Utils/Containers.h"
 
-#include <boost/lexical_cast.hpp>
 
 namespace L4 {
 namespace Utils {
@@ -19,25 +18,6 @@ class Properties : public StdStringKeyMap<std::string> {
   // Expose a constructor with initializer_list for convenience.
   Properties(std::initializer_list<Value> values) : Base(values) {}
 
-  // Returns true if the given key exists and the value associated with
-  // the key can be converted to the TValue type. If the conversion fails, the
-  // value of the given val is guaranteed to remain the same.
-  template <typename TValue>
-  bool TryGet(const std::string& key, TValue& val) const {
-    const auto it = find(key);
-    if (it == end()) {
-      return false;
-    }
-
-    TValue tmp;
-    if (!boost::conversion::try_lexical_convert(it->second, tmp)) {
-      return false;
-    }
-
-    val = tmp;
-
-    return true;
-  }
 };
 
 }  // namespace Utils

--- a/inc/L4/detail/ToRawPointer.h
+++ b/inc/L4/detail/ToRawPointer.h
@@ -1,11 +1,139 @@
 #pragma once
 
-#include <boost/interprocess/detail/utilities.hpp>
 
 namespace L4 {
 namespace Detail {
 
-using boost::interprocess::ipcdetail::to_raw_pointer;
+//#include <boost/interprocess/detail/utilities.hpp>
+#define L4_MAYBE_INLINE 
+
+template<class RawPointer>
+class pointer_uintptr_caster;
+
+template<class T>
+class pointer_uintptr_caster<T*>
+{
+   public:
+   L4_MAYBE_INLINE explicit pointer_uintptr_caster(uintptr_t sz)
+      : m_uintptr(sz)
+   {}
+
+   L4_MAYBE_INLINE explicit pointer_uintptr_caster(const volatile T *p)
+      : m_uintptr(reinterpret_cast<uintptr_t>(p))
+   {}
+
+   L4_MAYBE_INLINE uintptr_t uintptr() const
+   {   return m_uintptr;   }
+
+   L4_MAYBE_INLINE T* pointer() const
+   {   return reinterpret_cast<T*>(m_uintptr);   }
+
+   private:
+   uintptr_t m_uintptr;
+};
+
+template<class RawPointer>
+class pointer_size_t_caster
+{
+   public:
+   explicit pointer_size_t_caster(std::size_t sz)
+      : m_ptr(reinterpret_cast<RawPointer>(sz))
+   {}
+
+   explicit pointer_size_t_caster(RawPointer p)
+      : m_ptr(p)
+   {}
+
+   std::size_t size() const
+   {   return reinterpret_cast<std::size_t>(m_ptr);   }
+
+   RawPointer pointer() const
+   {   return m_ptr;   }
+
+   private:
+   RawPointer m_ptr;
+};
+
+
+template<class RawPointer, class OffsetType>
+class pointer_offset_caster;
+
+template<class T, class OffsetType>
+class pointer_offset_caster<T*, OffsetType>
+{
+   public:
+   L4_MAYBE_INLINE explicit pointer_offset_caster(OffsetType offset)
+      : m_offset(offset)
+   {}
+
+   L4_MAYBE_INLINE explicit pointer_offset_caster(const volatile T *p)
+      : m_offset(reinterpret_cast<OffsetType>(p))
+   {}
+
+   L4_MAYBE_INLINE OffsetType offset() const
+   {   return m_offset;   }
+
+   L4_MAYBE_INLINE T* pointer() const
+   {   return reinterpret_cast<T*>(m_offset);   }
+
+   private:
+   OffsetType m_offset;
+};
+
+
+
+#define BOOST_INTERPROCESS_OFFSET_PTR_BRANCHLESS_TO_PTR
+template <class OffsetType>
+L4_MAYBE_INLINE void *offset_ptr_to_raw_pointer(const volatile void *this_ptr, OffsetType offset) {
+  typedef pointer_offset_caster<void *, OffsetType> caster_t;
+#ifndef BOOST_INTERPROCESS_OFFSET_PTR_BRANCHLESS_TO_PTR
+  if (offset == 1) {
+    return 0;
+  } else {
+    return caster_t(caster_t(this_ptr).offset() + offset).pointer();
+  }
+#else
+  OffsetType mask = offset == 1;
+  --mask;
+  OffsetType target_offset = caster_t(this_ptr).offset() + offset;
+  target_offset &= mask;
+  return caster_t(target_offset).pointer();
+#endif
+}
+
+
+template <class T>
+L4_MAYBE_INLINE T* to_raw_pointer(T* p)
+{  return p; }
+
+template<class T>
+L4_MAYBE_INLINE std::size_t offset_ptr_to_offset(const volatile void *ptr, const volatile void *this_ptr)
+{
+   typedef pointer_size_t_caster<void*> caster_t;
+   #ifndef BOOST_INTERPROCESS_OFFSET_PTR_BRANCHLESS_TO_OFF
+      //offset == 1 && ptr != 0 is not legal for this pointer
+      if(!ptr){
+         return 1;
+      }
+      else{
+         caster_t this_caster((void*)this_ptr);
+         caster_t ptr_caster((void*)ptr);
+         std::size_t offset = ptr_caster.size() - this_caster.size();
+         assert(offset != 1);
+         return offset;
+      }
+   #else
+      caster_t this_caster((void*)this_ptr);
+      caster_t ptr_caster((void*)ptr);
+      std::size_t offset = (ptr_caster.size() - this_caster.size() - 1) & -std::size_t(ptr != 0);
+      ++offset;
+      return offset;
+   #endif
+}
+
+
+
+// using boost::interprocess::ipcdetail::to_raw_pointer;
 
 }  // namespace Detail
 }  // namespace L4

--- a/inc/L4/detail/ToRawPointer.h
+++ b/inc/L4/detail/ToRawPointer.h
@@ -4,7 +4,13 @@
 namespace L4 {
 namespace Detail {
 
-//#include <boost/interprocess/detail/utilities.hpp>
+// #include <boost/interprocess/detail/utilities.hpp>
+// using boost::interprocess::ipcdetail::to_raw_pointer;
+
+// The following subset of functions are copied over from the above header file
+// (or further includes) and are the minimum required ones to get L4 working
+// without pulling boost sources in entirety.
+
 #define L4_MAYBE_INLINE 
 
 template<class RawPointer>
@@ -133,7 +139,6 @@ L4_MAYBE_INLINE std::size_t offset_ptr_to_offset(const volatile void *ptr, const
 
 
 
-// using boost::interprocess::ipcdetail::to_raw_pointer;
 
 }  // namespace Detail
 }  // namespace L4

--- a/src/MurmurHash3.cpp
+++ b/src/MurmurHash3.cpp
@@ -29,7 +29,9 @@
 
 #else   // defined(_MSC_VER)
 
-#define FORCE_INLINE __attribute__((always_inline))
+// For position independent compiles
+// https://rt.cpan.org/Public/Bug/Display.html?id=91280
+#define FORCE_INLINE inline __attribute__((always_inline))
 
 inline uint32_t rotl32(uint32_t x, int8_t r)
 {

--- a/src/PerfLogger.cpp
+++ b/src/PerfLogger.cpp
@@ -1,6 +1,7 @@
+#include "Log/PerfCounter.h"
 #include "Log/PerfLogger.h"
-#include <boost/format.hpp>
 #include "Utils/Exception.h"
+#include <sstream>
 
 namespace L4 {
 
@@ -12,9 +13,10 @@ void PerfData::AddHashTablePerfData(const char* hashTableName,
       std::make_pair(hashTableName, HashTablesPerfData::mapped_type(perfData)));
 
   if (!result.second) {
-    boost::format err("Duplicate hash table name found: '%1%'.");
-    err % hashTableName;
-    throw RuntimeException(err.str());
+    std::stringstream stream;
+    stream << "Duplicate hash table name found: ";
+    stream << hashTableName;
+    throw RuntimeException(stream.str());
   }
 }
 


### PR DESCRIPTION
Necessary requirements to change L4 to work without boost. 

1. `boost::interprocess:vector` -> `std::vector`
2. `boost::interprocess::detail::*` -> pulled some sources/functions from boost source. Might want to get rid of these. 

The non-process stuff should work accordingly.